### PR TITLE
Add Hindi (India) language support

### DIFF
--- a/library/src/main/java/com/mapzen/valhalla/Router.kt
+++ b/library/src/main/java/com/mapzen/valhalla/Router.kt
@@ -9,7 +9,8 @@ interface Router {
         PIRATE("en-US-x-pirate"),
         ES_ES("es-ES"),
         FR_FR("fr-FR"),
-        IT_IT("it-IT");
+        IT_IT("it-IT"),
+        HI_IN("hi-IN");
 
         override fun toString(): String {
             return languageTag

--- a/library/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -92,6 +92,12 @@ public class RouterTest {
     }
 
     @Test
+    public void shouldSetToHiIn() throws Exception {
+        router.setLanguage(Router.Language.HI_IN);
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("hi-IN");
+    }
+
+    @Test
     public void shouldDefaultToCar() throws Exception {
         assertThat(router.getJSONRequest().costing).contains("auto");
     }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -20,5 +20,6 @@
     <item>ES_ES</item>
     <item>FR_FR</item>
     <item>IT_IT</item>
+    <item>HI_IN</item>
   </string-array>
 </resources>


### PR DESCRIPTION
Hindi support was pushed to production from ODIN (Example:
http://valhalla.mapzen.com/route?api_key=valhalla-UdVXVeg&json={%22locations%22:[{%22lat%22:40.730930,%22lon%22:-73.991379,%22street%22:%22Wanamaker%20Place%22},{%22lat%22:40.749706,%22lon%22:-73.991562,%22street%22:%22Penn%20Plaza%22}],%22costing%22:%22multimodal%22,%22directions_options%22:{%22units%22:%22miles%22,%22language%22:%22hi-IN%22},%22date_time%22:{%22type%22:1,%22value%22:%222015-12-29T08:00%22}} )