### PR TITLE
Numbers should be numbers (no quotes) in route request

### DIFF
--- a/library/src/main/java/com/mapzen/valhalla/JSON.java
+++ b/library/src/main/java/com/mapzen/valhalla/JSON.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class JSON {
-    public static final double HEADING_NONE = -1;
+    public static final int HEADING_NONE = -1;
 
     public List<JSON.Location> locations = new ArrayList<>();
     public String costing;
@@ -22,14 +22,14 @@ public class JSON {
         public String street;
         public String city;
         public String state;
-        public double heading = HEADING_NONE;
+        public int heading = HEADING_NONE;
 
         public Location(double lat, double lon) {
             this.lat = lat;
             this.lon = lon;
         }
 
-        public Location(double lat, double lon, double heading) {
+        public Location(double lat, double lon, int heading) {
             if (heading < 0 || heading >= 360) {
                 throw new IllegalArgumentException("Heading value must in the range [0, 360)");
             }

--- a/library/src/main/java/com/mapzen/valhalla/JSON.java
+++ b/library/src/main/java/com/mapzen/valhalla/JSON.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class JSON {
+    public static final double HEADING_NONE = -1;
+
     public List<JSON.Location> locations = new ArrayList<>();
     public String costing;
 
@@ -14,26 +16,30 @@ public class JSON {
     public DirectionOptions directionsOptions = new DirectionOptions();
 
     public static class Location {
-        public String lat;
-        public String lon;
+        public double lat;
+        public double lon;
         public String name;
         public String street;
         public String city;
         public String state;
-        public String heading;
+        public double heading = HEADING_NONE;
 
-        public Location(String lat, String lon) {
+        public Location(double lat, double lon) {
             this.lat = lat;
             this.lon = lon;
         }
 
-        public Location(String lat, String lon, String heading) {
+        public Location(double lat, double lon, double heading) {
+            if (heading < 0 || heading >= 360) {
+                throw new IllegalArgumentException("Heading value must in the range [0, 360)");
+            }
+
             this.lat = lat;
             this.lon = lon;
             this.heading = heading;
         }
 
-        public Location(String lat, String lon, String name, String street,
+        public Location(double lat, double lon, String name, String street,
                 String city, String state) {
             this.lat = lat;
             this.lon = lon;

--- a/library/src/main/java/com/mapzen/valhalla/LocationSerializer.java
+++ b/library/src/main/java/com/mapzen/valhalla/LocationSerializer.java
@@ -1,0 +1,21 @@
+package com.mapzen.valhalla;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+
+class LocationSerializer implements JsonSerializer<JSON.Location> {
+  @Override public JsonElement serialize(JSON.Location src, Type typeOfSrc,
+      JsonSerializationContext context) {
+    JsonObject jsonObject = (JsonObject) new GsonBuilder().create().toJsonTree(src);
+    if (src.heading < 0 || src.heading >= 360) {
+      jsonObject.remove("heading");
+    }
+
+    return jsonObject;
+  }
+}

--- a/library/src/main/java/com/mapzen/valhalla/Router.kt
+++ b/library/src/main/java/com/mapzen/valhalla/Router.kt
@@ -44,7 +44,7 @@ interface Router {
     fun setBiking(): Router
     fun setMultimodal(): Router
     fun setLocation(point: DoubleArray): Router
-    fun setLocation(point: DoubleArray, heading: Float): Router
+    fun setLocation(point: DoubleArray, heading: Double): Router
     fun setLocation(point: DoubleArray,
             name: String? = null,
             street: String? = null,

--- a/library/src/main/java/com/mapzen/valhalla/Router.kt
+++ b/library/src/main/java/com/mapzen/valhalla/Router.kt
@@ -44,7 +44,7 @@ interface Router {
     fun setBiking(): Router
     fun setMultimodal(): Router
     fun setLocation(point: DoubleArray): Router
-    fun setLocation(point: DoubleArray, heading: Double): Router
+    fun setLocation(point: DoubleArray, heading: Int): Router
     fun setLocation(point: DoubleArray,
             name: String? = null,
             street: String? = null,

--- a/library/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
+++ b/library/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
@@ -1,7 +1,7 @@
 package com.mapzen.valhalla
 
-import android.util.Log
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -18,7 +18,9 @@ open class ValhallaRouter : Router, Runnable {
 
     private var httpHandler: HttpHandler? = null
 
-    var gson: Gson = Gson()
+    private val gson: Gson = GsonBuilder()
+        .registerTypeAdapter(JSON.Location::class.java, LocationSerializer())
+        .create()
 
     override fun setHttpHandler(handler: HttpHandler): Router {
         httpHandler = handler
@@ -51,13 +53,12 @@ open class ValhallaRouter : Router, Runnable {
     }
 
     override fun setLocation(point: DoubleArray): Router {
-        this.locations.add(JSON.Location(point[0].toString(), point[1].toString()))
+        this.locations.add(JSON.Location(point[0], point[1]))
         return this
     }
 
-    override fun setLocation(point: DoubleArray, heading: Float): Router {
-        this.locations.add(JSON.Location(point[0].toString(), point[1].toString(),
-                heading.toInt().toString()))
+    override fun setLocation(point: DoubleArray, heading: Double): Router {
+        this.locations.add(JSON.Location(point[0], point[1], heading))
         return this
     }
 
@@ -67,7 +68,7 @@ open class ValhallaRouter : Router, Runnable {
             city: String?,
             state: String?): Router {
 
-        this.locations.add(JSON.Location(point[0].toString(), point[1].toString(),
+        this.locations.add(JSON.Location(point[0], point[1],
                 name, street, city, state));
         return this
     }

--- a/library/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
+++ b/library/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
@@ -57,7 +57,7 @@ open class ValhallaRouter : Router, Runnable {
         return this
     }
 
-    override fun setLocation(point: DoubleArray, heading: Double): Router {
+    override fun setLocation(point: DoubleArray, heading: Int): Router {
         this.locations.add(JSON.Location(point[0], point[1], heading))
         return this
     }

--- a/library/src/test/java/com/mapzen/valhalla/JSONTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/JSONTest.java
@@ -1,0 +1,37 @@
+package com.mapzen.valhalla;
+
+import org.junit.Test;
+
+public class JSONTest {
+  @Test
+  public void shouldNotThrowIfHeadingEqualsZero() throws Exception {
+    double lat = 0.0;
+    double lon = 0.0;
+    double heading = 0.0;
+    new JSON.Location(lat, lon, heading);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowIfHeadingLessThanZero() throws Exception {
+    double lat = 0.0;
+    double lon = 0.0;
+    double heading = -1.0;
+    new JSON.Location(lat, lon, heading);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowIfHeadingEquals360() throws Exception {
+    double lat = 0.0;
+    double lon = 0.0;
+    double heading = 360.0;
+    new JSON.Location(lat, lon, heading);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowIfHeadingIsGreaterThan360() throws Exception {
+    double lat = 0.0;
+    double lon = 0.0;
+    double heading = 361.0;
+    new JSON.Location(lat, lon, heading);
+  }
+}

--- a/library/src/test/java/com/mapzen/valhalla/JSONTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/JSONTest.java
@@ -7,7 +7,7 @@ public class JSONTest {
   public void shouldNotThrowIfHeadingEqualsZero() throws Exception {
     double lat = 0.0;
     double lon = 0.0;
-    double heading = 0.0;
+    int heading = 0;
     new JSON.Location(lat, lon, heading);
   }
 
@@ -15,7 +15,7 @@ public class JSONTest {
   public void shouldThrowIfHeadingLessThanZero() throws Exception {
     double lat = 0.0;
     double lon = 0.0;
-    double heading = -1.0;
+    int heading = -1;
     new JSON.Location(lat, lon, heading);
   }
 
@@ -23,7 +23,7 @@ public class JSONTest {
   public void shouldThrowIfHeadingEquals360() throws Exception {
     double lat = 0.0;
     double lon = 0.0;
-    double heading = 360.0;
+    int heading = 360;
     new JSON.Location(lat, lon, heading);
   }
 
@@ -31,7 +31,7 @@ public class JSONTest {
   public void shouldThrowIfHeadingIsGreaterThan360() throws Exception {
     double lat = 0.0;
     double lon = 0.0;
-    double heading = 361.0;
+    int heading = 361;
     new JSON.Location(lat, lon, heading);
   }
 }

--- a/library/src/test/java/com/mapzen/valhalla/LocationSerializerTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/LocationSerializerTest.java
@@ -18,36 +18,36 @@ public class LocationSerializerTest {
   @Before public void setUp() throws Exception {
     double lat = 0.0;
     double lon = 0.0;
-    double heading = 0.0;
+    int heading = 0;
     location = new JSON.Location(lat, lon, heading);
     locationSerializer = new LocationSerializer();
   }
 
   @Test public void shouldIncludeHeading() throws Exception {
     assertThat(locationSerializer.serialize(location, JSON.Location.class, null).toString())
-        .contains("\"heading\":0.0");
+        .contains("\"heading\":0");
   }
 
   @Test public void shouldExcludeHeadingLessThanZero() throws Exception {
     location.heading = -1;
     assertThat(locationSerializer.serialize(location, JSON.Location.class, null).toString())
-        .doesNotContain("\"heading\":-1.0");
+        .doesNotContain("\"heading\":-1");
   }
 
   @Test public void shouldExcludeHeadingEqualTo360() throws Exception {
     location.heading = 360;
     assertThat(locationSerializer.serialize(location, JSON.Location.class, null).toString())
-        .doesNotContain("\"heading\":360.0");
+        .doesNotContain("\"heading\":360");
   }
 
   @Test public void shouldExcludeHeadingGreaterThan360() throws Exception {
     location.heading = 361;
     assertThat(locationSerializer.serialize(location, JSON.Location.class, null).toString())
-        .doesNotContain("\"heading\":361.0");
+        .doesNotContain("\"heading\":361");
   }
 
   @Test public void shouldExcludeOnlyHeadingsOutOfRange() throws Exception {
-    JSON.Location location1 = new JSON.Location(1d, 2d, 0d);
+    JSON.Location location1 = new JSON.Location(1d, 2d, 0);
     JSON.Location location2 = new JSON.Location(3d, 4d);
     ArrayList<JSON.Location> locations = new ArrayList<>();
     locations.add(location1);
@@ -59,7 +59,7 @@ public class LocationSerializerTest {
         .registerTypeAdapter(JSON.Location.class, new LocationSerializer())
         .create();
     String result = gson.toJson(json);
-    assertThat(result).contains("\"lat\":1.0,\"lon\":2.0,\"heading\":0.0");
-    assertThat(result).doesNotContain("\"lat\":3.0,\"lon\":4.0,\"heading\":-1.0");
+    assertThat(result).contains("\"lat\":1.0,\"lon\":2.0,\"heading\":0");
+    assertThat(result).doesNotContain("\"lat\":3.0,\"lon\":4.0,\"heading\":-1");
   }
 }

--- a/library/src/test/java/com/mapzen/valhalla/LocationSerializerTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/LocationSerializerTest.java
@@ -1,0 +1,65 @@
+package com.mapzen.valhalla;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class LocationSerializerTest {
+
+  private LocationSerializer locationSerializer;
+  private JSON.Location location;
+
+  @Before public void setUp() throws Exception {
+    double lat = 0.0;
+    double lon = 0.0;
+    double heading = 0.0;
+    location = new JSON.Location(lat, lon, heading);
+    locationSerializer = new LocationSerializer();
+  }
+
+  @Test public void shouldIncludeHeading() throws Exception {
+    assertThat(locationSerializer.serialize(location, JSON.Location.class, null).toString())
+        .contains("\"heading\":0.0");
+  }
+
+  @Test public void shouldExcludeHeadingLessThanZero() throws Exception {
+    location.heading = -1;
+    assertThat(locationSerializer.serialize(location, JSON.Location.class, null).toString())
+        .doesNotContain("\"heading\":-1.0");
+  }
+
+  @Test public void shouldExcludeHeadingEqualTo360() throws Exception {
+    location.heading = 360;
+    assertThat(locationSerializer.serialize(location, JSON.Location.class, null).toString())
+        .doesNotContain("\"heading\":360.0");
+  }
+
+  @Test public void shouldExcludeHeadingGreaterThan360() throws Exception {
+    location.heading = 361;
+    assertThat(locationSerializer.serialize(location, JSON.Location.class, null).toString())
+        .doesNotContain("\"heading\":361.0");
+  }
+
+  @Test public void shouldExcludeOnlyHeadingsOutOfRange() throws Exception {
+    JSON.Location location1 = new JSON.Location(1d, 2d, 0d);
+    JSON.Location location2 = new JSON.Location(3d, 4d);
+    ArrayList<JSON.Location> locations = new ArrayList<>();
+    locations.add(location1);
+    locations.add(location2);
+    JSON json = new JSON();
+    json.locations = locations;
+
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapter(JSON.Location.class, new LocationSerializer())
+        .create();
+    String result = gson.toJson(json);
+    assertThat(result).contains("\"lat\":1.0,\"lon\":2.0,\"heading\":0.0");
+    assertThat(result).doesNotContain("\"lat\":3.0,\"lon\":4.0,\"heading\":-1.0");
+  }
+}

--- a/library/src/test/java/com/mapzen/valhalla/RouteTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/RouteTest.java
@@ -2,8 +2,6 @@ package com.mapzen.valhalla;
 
 import com.mapzen.model.ValhallaLocation;
 
-import com.google.common.io.Files;
-
 import org.apache.commons.io.FileUtils;
 import org.fest.assertions.data.Offset;
 import org.junit.Before;
@@ -18,7 +16,6 @@ import java.util.ListIterator;
 
 import static com.mapzen.TestUtils.getLocation;
 import static java.lang.System.getProperty;
-import static java.nio.charset.Charset.defaultCharset;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 @RunWith(RobolectricTestRunner.class)
@@ -525,19 +522,5 @@ public class RouteTest {
 
         route = getRoute("brooklyn_valhalla_miles");
         assertThat(route.getUnits()).isEqualTo(Router.DistanceUnits.MILES);
-    }
-
-    private ArrayList<ValhallaLocation> getLocationsFromFile(String name) throws Exception {
-        String fileName = getProperty("user.dir");
-        File file = new File(fileName + "/src/test/fixtures/" + name + ".txt");
-        ArrayList<ValhallaLocation> allLocations = new ArrayList<ValhallaLocation>();
-        for(String locations: Files.readLines(file, defaultCharset())) {
-            String[] latLng = locations.split(",");
-            ValhallaLocation location = new ValhallaLocation();
-            location.setLatitude(Double.valueOf(latLng[0]));
-            location.setLongitude(Double.valueOf(latLng[1]));
-            allLocations.add(location);
-        }
-        return allLocations;
     }
 }

--- a/library/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -312,7 +312,7 @@ public class RouterTest {
         double[] loc = new double[] {1.0, 2.0};
         router = new ValhallaRouter().setLocation(loc, 180).setLocation(loc);
         assertThat(new Gson().toJson(router.getJSONRequest()))
-                .contains("{\"lat\":1.0,\"lon\":2.0,\"heading\":180.0}");
+                .contains("{\"lat\":1.0,\"lon\":2.0,\"heading\":180}");
     }
 
     @Test

--- a/library/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -1,6 +1,7 @@
 package com.mapzen.valhalla;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import org.json.JSONObject;
 import org.junit.After;
@@ -137,9 +138,9 @@ public class RouterTest {
         router.setLocation(loc2);
         router.setLocation(loc3);
         JSON json = router.getJSONRequest();
-        assertThat(json.locations.get(0).lat).doesNotContain("1.0");
-        assertThat(json.locations.get(0).lat).contains("3.0");
-        assertThat(json.locations.get(1).lat).contains("5.0");
+        assertThat(json.locations.get(0).lat).isNotEqualTo(1.0);
+        assertThat(json.locations.get(0).lat).isEqualTo(3.0);
+        assertThat(json.locations.get(1).lat).isEqualTo(5.0);
     }
 
     @Test(expected=MalformedURLException.class)
@@ -160,10 +161,10 @@ public class RouterTest {
                 .setLocation(loc1)
                 .setLocation(loc2)
                 .getJSONRequest();
-        assertThat(json.locations.get(0).lat).contains("1.0");
-        assertThat(json.locations.get(0).lon).contains("2.0");
-        assertThat(json.locations.get(1).lat).contains("3.0");
-        assertThat(json.locations.get(1).lon).contains("4.0");
+        assertThat(json.locations.get(0).lat).isEqualTo(1.0);
+        assertThat(json.locations.get(0).lon).isEqualTo(2.0);
+        assertThat(json.locations.get(1).lat).isEqualTo(3.0);
+        assertThat(json.locations.get(1).lon).isEqualTo(4.0);
     }
 
     @Test
@@ -178,14 +179,14 @@ public class RouterTest {
             .setLocation(loc3)
             .setLocation(loc4)
             .getJSONRequest();
-        assertThat(json.locations.get(0).lat).contains("1.0");
-        assertThat(json.locations.get(0).lon).contains("2.0");
-        assertThat(json.locations.get(1).lat).contains("3.0");
-        assertThat(json.locations.get(1).lon).contains("4.0");
-        assertThat(json.locations.get(2).lat).contains("5.0");
-        assertThat(json.locations.get(2).lon).contains("6.0");
-        assertThat(json.locations.get(3).lat).contains("7.0");
-        assertThat(json.locations.get(3).lon).contains("8.0");
+        assertThat(json.locations.get(0).lat).isEqualTo(1.0);
+        assertThat(json.locations.get(0).lon).isEqualTo(2.0);
+        assertThat(json.locations.get(1).lat).isEqualTo(3.0);
+        assertThat(json.locations.get(1).lon).isEqualTo(4.0);
+        assertThat(json.locations.get(2).lat).isEqualTo(5.0);
+        assertThat(json.locations.get(2).lon).isEqualTo(6.0);
+        assertThat(json.locations.get(3).lat).isEqualTo(7.0);
+        assertThat(json.locations.get(3).lon).isEqualTo(8.0);
     }
 
     @Test
@@ -277,8 +278,11 @@ public class RouterTest {
         double[] loc = new double[] {1.0, 2.0};
         router = new ValhallaRouter().setLocation(loc)
                 .setLocation(loc, "Acme", null, null, null);
-        assertThat(new Gson().toJson(router.getJSONRequest()))
-                .contains("{\"lat\":\"1.0\",\"lon\":\"2.0\",\"name\":\"Acme\"}");
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapter(JSON.Location.class, new LocationSerializer())
+            .create();
+        assertThat(gson.toJson(router.getJSONRequest()))
+                .contains("{\"lat\":1.0,\"lon\":2.0,\"name\":\"Acme\"}");
     }
 
     @Test
@@ -292,8 +296,11 @@ public class RouterTest {
         double[] loc = new double[] {1.0, 2.0};
         router = new ValhallaRouter()
                 .setLocation(loc).setLocation(loc, "Acme", "North Main Street", "Doylestown", "PA");
-        assertThat(new Gson().toJson(router.getJSONRequest()))
-                .contains("{\"lat\":\"1.0\",\"lon\":\"2.0\","
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapter(JSON.Location.class, new LocationSerializer())
+            .create();
+        assertThat(gson.toJson(router.getJSONRequest()))
+                .contains("{\"lat\":1.0,\"lon\":2.0,"
                         + "\"name\":\"Acme\","
                         + "\"street\":\"North Main Street\","
                         + "\"city\":\"Doylestown\","
@@ -305,7 +312,7 @@ public class RouterTest {
         double[] loc = new double[] {1.0, 2.0};
         router = new ValhallaRouter().setLocation(loc, 180).setLocation(loc);
         assertThat(new Gson().toJson(router.getJSONRequest()))
-                .contains("{\"lat\":\"1.0\",\"lon\":\"2.0\",\"heading\":\"180\"}");
+                .contains("{\"lat\":1.0,\"lon\":2.0,\"heading\":180.0}");
     }
 
     @Test


### PR DESCRIPTION
Fixes issue where request fields including `lat`, `lon`, and `heading` values would be treated as a string (wrapped in quotes) instead of a number.

Heading should only be included in requests where it is explicitly set.

* Converts `lat`, `lon`, ~~and `heading`~~ fields in `JSON.Location` from type `String` to `double`. The `heading` field is now treated as an `int`.
* Adds input validation to ensure heading is in the range [0, 360).
* Implements custom GSON serializer for `JSON.Location` class to remove heading field if not explicitly set.
* Updates `ValhallaRouter` to use custom serializer class.
* Updates tests and removes unused test helper method ` getLocationsFromFile(String name)`.

Fixes #105 

See also https://github.com/valhalla/valhalla/pull/582