### PR TITLE
Use default Locale if no language specified

### DIFF
--- a/library/src/main/java/com/mapzen/valhalla/Router.kt
+++ b/library/src/main/java/com/mapzen/valhalla/Router.kt
@@ -3,14 +3,14 @@ package com.mapzen.valhalla
 interface Router {
 
     enum class Language(private val languageTag: String) {
-        CS_CZ("cs-CZ"),
-        DE_DE("de-DE"),
-        EN_US("en-US"),
-        PIRATE("en-US-x-pirate"),
-        ES_ES("es-ES"),
-        FR_FR("fr-FR"),
-        IT_IT("it-IT"),
-        HI_IN("hi-IN");
+        CS_CZ("cs"),
+        DE_DE("de"),
+        EN_US("en"),
+        PIRATE("pirate"),
+        ES_ES("es"),
+        FR_FR("fr"),
+        IT_IT("it"),
+        HI_IN("hi");
 
         override fun toString(): String {
             return languageTag

--- a/library/src/main/java/com/mapzen/valhalla/Router.kt
+++ b/library/src/main/java/com/mapzen/valhalla/Router.kt
@@ -3,14 +3,14 @@ package com.mapzen.valhalla
 interface Router {
 
     enum class Language(private val languageTag: String) {
-        CS_CZ("cs"),
-        DE_DE("de"),
-        EN_US("en"),
-        PIRATE("pirate"),
-        ES_ES("es"),
-        FR_FR("fr"),
-        IT_IT("it"),
-        HI_IN("hi");
+        CS_CZ("cs-CZ"),
+        DE_DE("de-DE"),
+        EN_US("en-US"),
+        PIRATE("en-US-x-pirate"),
+        ES_ES("es-ES"),
+        FR_FR("fr-FR"),
+        IT_IT("it-IT"),
+        HI_IN("hi-IN");
 
         override fun toString(): String {
             return languageTag

--- a/library/src/main/java/com/mapzen/valhalla/Router.kt
+++ b/library/src/main/java/com/mapzen/valhalla/Router.kt
@@ -10,7 +10,9 @@ interface Router {
         ES_ES("es-ES"),
         FR_FR("fr-FR"),
         IT_IT("it-IT"),
-        HI_IN("hi-IN");
+        HI_IN("hi-IN"),
+        CA_ES("ca-ES"),
+        SL_SI("sl-SI");
 
         override fun toString(): String {
             return languageTag

--- a/library/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
+++ b/library/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
@@ -7,10 +7,11 @@ import retrofit2.Callback
 import retrofit2.Response
 import java.net.MalformedURLException
 import java.util.ArrayList
+import java.util.Locale
 
 open class ValhallaRouter : Router, Runnable {
 
-    private var language = Router.Language.EN_US
+    private var language = Locale.getDefault().language
     private var type = Router.Type.DRIVING
     private val locations = ArrayList<JSON.Location>()
     private var callback: RouteCallback? = null
@@ -28,7 +29,7 @@ open class ValhallaRouter : Router, Runnable {
     }
 
     override fun setLanguage(language: Router.Language): Router {
-        this.language = language
+        this.language = language.toString()
         return this
     }
 
@@ -124,7 +125,7 @@ open class ValhallaRouter : Router, Runnable {
         }
 
         json.costing = this.type.toString()
-        json.directionsOptions.language = this.language.toString()
+        json.directionsOptions.language = language
         json.directionsOptions.units = this.units.toString()
         return json
     }

--- a/library/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
+++ b/library/src/main/java/com/mapzen/valhalla/ValhallaRouter.kt
@@ -11,7 +11,7 @@ import java.util.Locale
 
 open class ValhallaRouter : Router, Runnable {
 
-    private var language = Locale.getDefault().language
+    private var language: String? = null
     private var type = Router.Type.DRIVING
     private val locations = ArrayList<JSON.Location>()
     private var callback: RouteCallback? = null
@@ -124,9 +124,19 @@ open class ValhallaRouter : Router, Runnable {
             json.locations.add(locations[i])
         }
 
+        if (language == null) {
+            language = getDefaultLanguage()
+        }
+
         json.costing = this.type.toString()
         json.directionsOptions.language = language
         json.directionsOptions.units = this.units.toString()
         return json
+    }
+
+    fun getDefaultLanguage(): String? {
+        val locale = Locale.getDefault().language + "-" + Locale.getDefault().country
+        return if (Router.Language.values().any { it.toString() == locale }) locale
+            else Locale.getDefault().language
     }
 }

--- a/library/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import java.net.MalformedURLException;
+import java.util.Locale;
 
 import static com.mapzen.TestUtils.getRouteFixture;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -45,56 +46,59 @@ public class RouterTest {
     }
 
     @Test
-    public void shouldDefaultToEnUs() throws Exception {
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("en-US");
+    public void shouldUseDefaultLocaleIfNoLanguageSpecified() throws Exception {
+        Locale.setDefault(Locale.FRANCE);
+        double[] loc = new double[] {1.0, 2.0};
+        router = new ValhallaRouter().setLocation(loc).setLocation(loc);
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("fr");
     }
 
     @Test
     public void shouldSetToCsCs() throws Exception {
         router.setLanguage(Router.Language.CS_CZ);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("cs-CZ");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("cs");
     }
 
     @Test
     public void shouldSetToDeDe() throws Exception {
         router.setLanguage(Router.Language.DE_DE);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("de-DE");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("de");
     }
 
     @Test
     public void shouldSetToEnUs() throws Exception {
         router.setLanguage(Router.Language.EN_US);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("en-US");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("en");
     }
 
     @Test
     public void shouldSetToEnUsPirate() throws Exception {
         router.setLanguage(Router.Language.PIRATE);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("en-US-x-pirate");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("pirate");
     }
 
     @Test
     public void shouldSetToEsEs() throws Exception {
         router.setLanguage(Router.Language.ES_ES);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("es-ES");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("es");
     }
 
     @Test
     public void shouldSetToFrFr() throws Exception {
         router.setLanguage(Router.Language.FR_FR);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("fr-FR");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("fr");
     }
 
     @Test
     public void shouldSetToItIt() throws Exception {
         router.setLanguage(Router.Language.IT_IT);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("it-IT");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("it");
     }
 
     @Test
     public void shouldSetToHiIn() throws Exception {
         router.setLanguage(Router.Language.HI_IN);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("hi-IN");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("hi");
     }
 
     @Test
@@ -266,11 +270,11 @@ public class RouterTest {
     public void setDistanceUnits_shouldAppendUnitsToJson() throws Exception {
         router.setDistanceUnits(Router.DistanceUnits.MILES);
         assertThat(new Gson().toJson(router.getJSONRequest()))
-                .contains("\"directions_options\":{\"units\":\"miles\",\"language\":\"en-US\"}");
+                .contains("\"directions_options\":{\"units\":\"miles\"");
 
         router.setDistanceUnits(Router.DistanceUnits.KILOMETERS);
         assertThat(new Gson().toJson(router.getJSONRequest()))
-                .contains("\"directions_options\":{\"units\":\"kilometers\",\"language\":\"en-US\"}");
+                .contains("\"directions_options\":{\"units\":\"kilometers\"");
     }
 
     @Test

--- a/library/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -46,59 +46,69 @@ public class RouterTest {
     }
 
     @Test
-    public void shouldUseDefaultLocaleIfNoLanguageSpecified() throws Exception {
+    public void shouldUseFourCharacterLanguageCodeIfDefaultIsSupported() throws Exception {
         Locale.setDefault(Locale.FRANCE);
         double[] loc = new double[] {1.0, 2.0};
         router = new ValhallaRouter().setLocation(loc).setLocation(loc);
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("fr-FR");
+    }
+
+    @Test
+    public void shouldUseTwoCharacterLanguageCodeIfDefaultIsNotSupported() throws Exception {
+        Locale.setDefault(Locale.CANADA_FRENCH);
+        double[] loc = new double[] {1.0, 2.0};
+        router = new ValhallaRouter().setLocation(loc).setLocation(loc);
         assertThat(router.getJSONRequest().directionsOptions.language).contains("fr");
+        assertThat(router.getJSONRequest().directionsOptions.language).doesNotContain("-FR");
+        assertThat(router.getJSONRequest().directionsOptions.language).doesNotContain("-CA");
     }
 
     @Test
     public void shouldSetToCsCs() throws Exception {
         router.setLanguage(Router.Language.CS_CZ);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("cs");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("cs-CZ");
     }
 
     @Test
     public void shouldSetToDeDe() throws Exception {
         router.setLanguage(Router.Language.DE_DE);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("de");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("de-DE");
     }
 
     @Test
     public void shouldSetToEnUs() throws Exception {
         router.setLanguage(Router.Language.EN_US);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("en");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("en-US");
     }
 
     @Test
     public void shouldSetToEnUsPirate() throws Exception {
         router.setLanguage(Router.Language.PIRATE);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("pirate");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("en-US-x-pirate");
     }
 
     @Test
     public void shouldSetToEsEs() throws Exception {
         router.setLanguage(Router.Language.ES_ES);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("es");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("es-ES");
     }
 
     @Test
     public void shouldSetToFrFr() throws Exception {
         router.setLanguage(Router.Language.FR_FR);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("fr");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("fr-FR");
     }
 
     @Test
     public void shouldSetToItIt() throws Exception {
         router.setLanguage(Router.Language.IT_IT);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("it");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("it-IT");
     }
 
     @Test
     public void shouldSetToHiIn() throws Exception {
         router.setLanguage(Router.Language.HI_IN);
-        assertThat(router.getJSONRequest().directionsOptions.language).contains("hi");
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("hi-IN");
     }
 
     @Test

--- a/library/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -112,6 +112,18 @@ public class RouterTest {
     }
 
     @Test
+    public void shouldSetToCaEs() throws Exception {
+        router.setLanguage(Router.Language.CA_ES);
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("ca-ES");
+    }
+
+    @Test
+    public void shouldSetToSlSi() throws Exception {
+        router.setLanguage(Router.Language.SL_SI);
+        assertThat(router.getJSONRequest().directionsOptions.language).contains("sl-SI");
+    }
+
+    @Test
     public void shouldDefaultToCar() throws Exception {
         assertThat(router.getJSONRequest().costing).contains("auto");
     }


### PR DESCRIPTION
Uses device default Locale to set request language if none has been explicitly set.

Relies on Valhalla falling back to en-US if the device language is not currently supported.

https://github.com/valhalla/valhalla-docs/blob/master/api-reference.md#directions-options

~~This change also switches to using the Valhalla two-character alias for language (dropping country code) to simplify logic when using the default Locale (not needing to build language + country code string). It will also allow us to better match multiple countries that share a language even if that region is not currently "supported".~~

~~For example, if the device locale is set to French (Guinee) sending the language and country code `fr-GN` to Valhalla would result in using English as the fallback whereas passing just the language code `fr` will ensure French `fr-FR` is used for the route narrative.~~

Uses language + country code if the language and region is in the list of currently support languages. Otherwise uses language code only.

Fixes #106 