### PR TITLE
Run dex in process

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=1.2.1-SNAPSHOT
 
-org.gradle.jvmargs=-XX:MaxHeapSize\=512m -Xmx512m
+org.gradle.jvmargs=-XX:MaxHeapSize\=2048m -Xmx2048m
 
 GROUP=com.mapzen
 VERSION_NAME=1.2.1-SNAPSHOT


### PR DESCRIPTION
Increase gradle memory allocation so dex runs in process (https://medium.com/google-developers/faster-android-studio-builds-with-dex-in-process-5988ed8aa37e)