### PR TITLE
Enable TLS 1.2 on pre-lollipop devices

### DIFF
--- a/library/src/main/java/com/mapzen/http/Tls12OkHttpClientFactory.kt
+++ b/library/src/main/java/com/mapzen/http/Tls12OkHttpClientFactory.kt
@@ -1,0 +1,63 @@
+package com.mapzen.http
+
+import android.os.Build
+import okhttp3.ConnectionSpec
+import okhttp3.TlsVersion
+import android.util.Log
+import okhttp3.OkHttpClient
+import java.security.KeyStore
+import java.util.ArrayList
+import java.util.Arrays
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
+
+
+/**
+ * Created by sarahlensing on 5/25/17.
+ */
+class Tls12OkHttpClientFactory {
+
+  /**
+   * Enables TLS 1.2 support for pre-lollipop on given [OkHttpClient.Builder].
+   * @param client Client to enable TLS on.
+   * *
+   * @return TLS enabled client.
+   */
+  companion object {
+    fun enableTls12OnPreLollipop(client: OkHttpClient.Builder): OkHttpClient.Builder {
+      if (Build.VERSION.SDK_INT in 16..21) {
+        try {
+          val sc = SSLContext.getInstance("TLSv1.2")
+          sc.init(null, null, null)
+
+          val trustManagerFactory = TrustManagerFactory.getInstance(
+              TrustManagerFactory.getDefaultAlgorithm())
+          trustManagerFactory.init(null as KeyStore?)
+          val trustManagers = trustManagerFactory.getTrustManagers()
+          if (trustManagers.size != 1 || trustManagers[0] !is X509TrustManager) {
+            throw IllegalStateException(
+                "Unexpected default trust managers:" + Arrays.toString(trustManagers))
+          }
+          val trustManager = trustManagers[0] as X509TrustManager
+          client.sslSocketFactory(Tls12SocketFactory(sc.getSocketFactory()), trustManager)
+
+          val cs = ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+              .tlsVersions(TlsVersion.TLS_1_2)
+              .build()
+
+          val specs = ArrayList<ConnectionSpec>()
+          specs.add(cs)
+          specs.add(ConnectionSpec.COMPATIBLE_TLS)
+          specs.add(ConnectionSpec.CLEARTEXT)
+
+          client.connectionSpecs(specs)
+        } catch (exc: Exception) {
+          Log.e("OkHttpTLSCompat", "Error while setting TLS 1.2", exc)
+        }
+
+      }
+      return client
+    }
+  }
+}

--- a/library/src/main/java/com/mapzen/http/Tls12OkHttpClientFactory.kt
+++ b/library/src/main/java/com/mapzen/http/Tls12OkHttpClientFactory.kt
@@ -14,7 +14,7 @@ import javax.net.ssl.X509TrustManager
 
 
 /**
- * Created by sarahlensing on 5/25/17.
+ * Enables TLS 1.2 for [OkHttpClient.Builder].
  */
 class Tls12OkHttpClientFactory {
 

--- a/library/src/main/java/com/mapzen/http/Tls12SocketFactory.kt
+++ b/library/src/main/java/com/mapzen/http/Tls12SocketFactory.kt
@@ -1,0 +1,74 @@
+package com.mapzen.http
+
+import java.io.IOException
+import java.net.InetAddress
+import java.net.Socket
+
+import javax.net.ssl.SSLSocket
+import javax.net.ssl.SSLSocketFactory
+
+/**
+ * From https://github.com/square/okhttp/issues/2372.
+
+ * Enables TLS v1.2 when creating SSLSockets.
+ *
+ *
+ * For some reason, android supports TLS v1.2 from API 16, but enables it by
+ * default only from API 20.
+ * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+ * *
+ * @see SSLSocketFactory
+ */
+class Tls12SocketFactory
+/**
+ * Public constructor.
+ * @param base
+ */
+(internal val delegate: SSLSocketFactory) : SSLSocketFactory() {
+
+  override fun getDefaultCipherSuites(): Array<String> {
+    return delegate.defaultCipherSuites
+  }
+
+  override fun getSupportedCipherSuites(): Array<String> {
+    return delegate.supportedCipherSuites
+  }
+
+  @Throws(IOException::class)
+  override fun createSocket(s: Socket, host: String, port: Int, autoClose: Boolean): Socket {
+    return patch(delegate.createSocket(s, host, port, autoClose))
+  }
+
+  @Throws(IOException::class)
+  override fun createSocket(host: String, port: Int): Socket {
+    return patch(delegate.createSocket(host, port))
+  }
+
+  @Throws(IOException::class)
+  override fun createSocket(host: String, port: Int, localHost: InetAddress,
+      localPort: Int): Socket {
+    return patch(delegate.createSocket(host, port, localHost, localPort))
+  }
+
+  @Throws(IOException::class)
+  override fun createSocket(host: InetAddress, port: Int): Socket {
+    return patch(delegate.createSocket(host, port))
+  }
+
+  @Throws(IOException::class)
+  override fun createSocket(address: InetAddress, port: Int, localAddress: InetAddress,
+      localPort: Int): Socket {
+    return patch(delegate.createSocket(address, port, localAddress, localPort))
+  }
+
+  private fun patch(s: Socket): Socket {
+    if (s is SSLSocket) {
+      s.enabledProtocols = TLS_V12_ONLY
+    }
+    return s
+  }
+
+  companion object {
+    private val TLS_V12_ONLY = arrayOf("TLSv1.2")
+  }
+}

--- a/library/src/main/java/com/mapzen/valhalla/HttpHandler.java
+++ b/library/src/main/java/com/mapzen/valhalla/HttpHandler.java
@@ -1,5 +1,7 @@
 package com.mapzen.valhalla;
 
+import com.mapzen.http.Tls12OkHttpClientFactory;
+
 import java.io.IOException;
 
 import okhttp3.Interceptor;
@@ -50,7 +52,9 @@ public class HttpHandler {
   }
 
   protected void configure(String endpoint, HttpLoggingInterceptor.Level logLevel) {
-    final OkHttpClient client = new OkHttpClient.Builder()
+    final OkHttpClient.Builder builder = Tls12OkHttpClientFactory.Companion.
+        enableTls12OnPreLollipop(new OkHttpClient.Builder());
+    final OkHttpClient client = builder
         .addNetworkInterceptor(requestInterceptor)
         .addNetworkInterceptor(new HttpLoggingInterceptor().setLevel(logLevel))
         .build();


### PR DESCRIPTION
### Overview
Enables TLS 1.2 on pre-lollipop devices and updates the sample activity to log requests in debug mode

### Proposed Changes
TLS 1.2 is disabled by default on devices running OS versions below 5.0. Coupled with Fastly upgrading to TLS 1.2, SSL is broken on devices running pre-lollipop OS versions. This change enables TLS 1.2 as recommended here: https://github.com/square/okhttp/issues/2372#issuecomment-244807676

Closes #115 