### PR TITLE
Allow request cancellation

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -78,11 +78,10 @@ repositories {
 dependencies {
   compile 'com.android.support:appcompat-v7:25.1.0'
   compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  compile 'com.squareup.okhttp3:okhttp:3.5.0'
-  compile 'com.squareup.okhttp3:logging-interceptor:3.5.0'
-  compile 'com.squareup.retrofit2:retrofit:2.1.0'
-  compile 'com.squareup.retrofit2:converter-gson:2.1.0'
-  compile 'com.squareup.retrofit2:converter-scalars:2.1.0'
+  compile 'com.squareup.okhttp3:logging-interceptor:3.8.0'
+  compile 'com.squareup.retrofit2:retrofit:2.3.0'
+  compile 'com.squareup.retrofit2:converter-gson:2.3.0'
+  compile 'com.squareup.retrofit2:converter-scalars:2.3.0'
 
   compile 'com.f2prateek.ln:ln:1.1.1'
   testCompile 'junit:junit:4.12'

--- a/library/src/main/java/com/mapzen/valhalla/Router.kt
+++ b/library/src/main/java/com/mapzen/valhalla/Router.kt
@@ -1,5 +1,7 @@
 package com.mapzen.valhalla
 
+import retrofit2.Call
+
 interface Router {
 
     enum class Language(private val languageTag: String) {
@@ -56,6 +58,6 @@ interface Router {
     fun setDistanceUnits(units: DistanceUnits): Router
     fun clearLocations(): Router
     fun setCallback(callback: RouteCallback): Router
-    fun fetch()
+    fun fetch(): Call<String>?
     fun getJSONRequest(): JSON
 }

--- a/library/src/main/java/com/mapzen/valhalla/RoutingService.java
+++ b/library/src/main/java/com/mapzen/valhalla/RoutingService.java
@@ -5,5 +5,5 @@ import retrofit2.http.Query;
 import retrofit2.Call;
 
 public interface RoutingService {
-    @GET("/route") Call<String> getRoute(@Query("json") String json);
+    @GET("/route") Call<String> getRoute(@Query("json") JSON json);
 }

--- a/library/src/test/java/com/mapzen/valhalla/HttpHandlerTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/HttpHandlerTest.java
@@ -46,7 +46,7 @@ public class HttpHandlerTest {
         .setLocation(new double[] { 40.671773, -73.981115 });
     RouteCallback callback = Mockito.mock(RouteCallback.class);
     router.setCallback(callback);
-    ((ValhallaRouter) router).run();
+    router.fetch();
     assertThat(httpHandler.headersAdded).isTrue();
   }
 }

--- a/library/src/test/java/com/mapzen/valhalla/RouterTest.java
+++ b/library/src/test/java/com/mapzen/valhalla/RouterTest.java
@@ -231,7 +231,7 @@ public class RouterTest {
             .setLocation(new double[] { 40.659241, -73.983776 })
             .setLocation(new double[] { 40.671773, -73.981115 });
         router.setCallback(callback);
-        ((ValhallaRouter) router).run();
+        router.fetch();
         Mockito.verify(callback).success(route.capture());
         assertThat(route.getValue().foundRoute()).isTrue();
     }
@@ -245,7 +245,7 @@ public class RouterTest {
             .setLocation(new double[]{40.659241, -73.983776})
             .setLocation(new double[]{40.671773, -73.981115});
         router.setCallback(callback);
-        ((ValhallaRouter) router).run();
+        router.fetch();
         Mockito.verify(callback).failure(statusCode.capture());
         assertThat(statusCode.getValue()).isEqualTo(500);
     }
@@ -259,7 +259,7 @@ public class RouterTest {
             .setLocation(new double[]{40.659241, -73.983776})
             .setLocation(new double[]{40.671773, -73.981115});
         router.setCallback(callback);
-        ((ValhallaRouter) router).run();
+        router.fetch();
         Mockito.verify(callback).failure(statusCode.capture());
         assertThat(statusCode.getValue()).isEqualTo(404);
     }
@@ -273,7 +273,7 @@ public class RouterTest {
             .setLocation(new double[] { 40.659241, -73.983776 })
             .setLocation(new double[] { 40.671773, -73.981115 });
         router.setCallback(callback);
-        ((ValhallaRouter) router).run();
+        router.fetch();
         Mockito.verify(callback).failure(statusCode.capture());
         assertThat(statusCode.getValue()).isEqualTo(400);
     }
@@ -288,7 +288,7 @@ public class RouterTest {
             .setLocation(new double[] { 40.659241, -73.983776 })
             .setLocation(new double[] { 40.671773, -73.981115 });
         router.setCallback(callback);
-        ((ValhallaRouter) router).run();
+        router.fetch();
         Mockito.verify(callback).success(route.capture());
         assertThat(route.getValue().getRawRoute().toString())
             .isEqualTo(new JSONObject(routeJson).toString());
@@ -357,7 +357,7 @@ public class RouterTest {
                 .setHttpHandler(httpHandler)
                 .setLocation(new double[] { 40.659241, -73.983776 })
                 .setLocation(new double[] { 40.671773, -73.981115 });
-        ((ValhallaRouter) router).run();
+        router.fetch();
         assertThat(httpHandler.route.raw().request().url().toString()).contains(endpoint);
     }
 

--- a/library/src/test/java/com/mapzen/valhalla/TestHttpHandler.java
+++ b/library/src/test/java/com/mapzen/valhalla/TestHttpHandler.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import okhttp3.Interceptor;
 import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
@@ -18,13 +19,16 @@ class TestHttpHandler extends HttpHandler {
     super(endpoint, logLevel);
   }
 
-  @Override public void requestRoute(String routeJson, Callback<String> callback) {
+  @Override public Call requestRoute(JSON routeJson, Callback<String> callback) {
+    Call call = null;
     try {
-      route = service.getRoute(routeJson).execute();
+      call = service.getRoute(routeJson);
+      route = call.execute();
     } catch (IOException e) {
       e.printStackTrace();
     }
     callback.onResponse(null, route);
+    return call;
   }
 
   @Override protected okhttp3.Response onRequest(Interceptor.Chain chain) throws IOException {


### PR DESCRIPTION
- Updates dependencies to latest versions
- Moves `GSON` conversion into Retrofit `Converter`
- Returns Retrofit `Call` object to allow `Call#cancel()`
- Updates tests

Wrapper `Call` object will live in the Android SDK and this repo will be coalesced into the SDK

Closes #99 